### PR TITLE
Multi-org auth with LDAP

### DIFF
--- a/application.ini.example
+++ b/application.ini.example
@@ -23,6 +23,14 @@ vcloud.endpoint = https://www.example.com/vcloud/api
 # Catalogue config file
 catalogue.file = /path/to/catalogue.json
 
+# LDAP configuration
+ldap.server = ldap://ldap.example.com
+ldap.bind_dn = CN=someuser,OU=Users,DC=example,DC=com
+ldap.bind_pass = P@s5w0rd
+ldap.user_base = OU=Users,DC=example,DC=com
+ldap.group_base = OU=Groups,DC=example,DC=com
+ldap.group_pattern = (?P<org>.*)_vcloud-admins
+
 # Secrets
 session.secret = asecret
 auth.secret = anothersecret

--- a/application.ini.example
+++ b/application.ini.example
@@ -18,10 +18,14 @@ pyramid.includes = pyramid_debugtoolbar
 # debugtoolbar.hosts = 127.0.0.1 ::1
 
 # vCloud endpoint
-vcloud_endpoint = https://www.example.com/vcloud/api
+vcloud.endpoint = https://www.example.com/vcloud/api
 
 # Catalogue config file
-catalogue_file = /path/to/catalogue.json
+catalogue.file = /path/to/catalogue.json
+
+# Secrets
+session.secret = asecret
+auth.secret = anothersecret
 
 
 ###

--- a/jasmin_portal/__init__.py
+++ b/jasmin_portal/__init__.py
@@ -22,7 +22,7 @@ def main(global_config, **settings):
     config = Configurator(
         settings = settings,
         # TODO: Provide a better secret
-        session_factory = SignedCookieSessionFactory('FIXME')
+        session_factory = SignedCookieSessionFactory(settings['session.secret'])
     )
 
     # We want to use Jinja2 templates
@@ -34,7 +34,7 @@ def main(global_config, **settings):
     config.set_request_factory(RequestFactory)
     # We want to use token based authentication, with a check on the vCD session
     config.set_authentication_policy(AuthTktAuthenticationPolicy(
-        'MY_SECRET', hashalg = 'sha512', callback = check_session
+        settings['auth.secret'], hashalg = 'sha512', callback = check_session
     ))
     # We use a basic ACL policy for authorisation
     config.set_authorization_policy(ACLAuthorizationPolicy())

--- a/jasmin_portal/cloud.py
+++ b/jasmin_portal/cloud.py
@@ -1,0 +1,52 @@
+"""
+Module that provides functionality for persisting cloud sessions across requests
+"""
+
+__author__ = "Matt Pryor"
+__copyright__ = "Copyright 2015 UK Science and Technology Facilities Council"
+
+
+def setup(config, settings):
+    """
+    Given a pyramid configurator and a settings dictionary, configure the cloud
+    integration for the app
+    """
+    # Add additional methods and properties to request
+    
+    SESSION_KEY = 'cloud'
+    
+    def _store(request):
+        # Returns the cloud_session dictionary from the Pyramid session, creating
+        # it if it doesn't exist
+        if SESSION_KEY not in request.session:
+            request.session[SESSION_KEY] = {}
+        return request.session[SESSION_KEY]
+    
+    def add_cloud_session(request, org, session):
+        # Adds the given cloud session to the Pyramid session, associated with
+        # the given org
+        _store(request)[org] = session
+        
+    def get_cloud_session(request, org):
+        # Returns the cloud session associated with the org, or None if none exists
+        return _store(request).get(org, None)
+    
+    def clear_cloud_sessions(request):
+        # Closes and clears all cloud sessions associated with the current
+        # Pyramid session
+        store = _store(request)
+        for s in store.values():
+            s.close()
+        store.clear()
+            
+    def active_cloud_session(request):
+        # Returns the active cloud session based on the org in the URI, or
+        # None if one does not exist
+        return request.get_cloud_session(request.current_org)
+            
+    config.add_request_method(add_cloud_session)
+    config.add_request_method(get_cloud_session)
+    config.add_request_method(clear_cloud_sessions)
+    config.add_request_method(active_cloud_session, reify = True)
+    
+    return config

--- a/jasmin_portal/cloudservices/__init__.py
+++ b/jasmin_portal/cloudservices/__init__.py
@@ -136,9 +136,9 @@ class Session(metaclass = abc.ABCMeta):
         self.close()
         
     @abc.abstractmethod
-    def is_active(self):
+    def poll(self):
         """
-        Checks if the session is still active
+        Returns True if the session is authenticated and active
         """
     
     @abc.abstractmethod

--- a/jasmin_portal/cloudservices/vcloud/__init__.py
+++ b/jasmin_portal/cloudservices/vcloud/__init__.py
@@ -71,7 +71,7 @@ def check_response(res):
     For the status codes returned by the vCD API, see
     http://pubs.vmware.com/vcd-55/topic/com.vmware.vcloud.api.doc_55/GUID-D2B2E6D4-7A92-4D1B-80C0-F32AE0CA3D11.html
     """
-        
+    
     # Check the status code
     if res.status_code == 503:
         # requests reports a 503 if it can't reach the server at all
@@ -204,7 +204,7 @@ fi
             path = '/'.join([self.__endpoint, path.strip('/')])
         # Make the request
         if self.__session is None:
-            raise ImplementationError('Session has already been closed')
+            raise InvalidActionError('Session has already been closed')
         func = getattr(self.__session, method.lower(), None)
         if func is None:
             raise ImplementationError('Invalid HTTP method - {}'.format(method))
@@ -241,16 +241,10 @@ fi
             # Any other statuses, we sleep before fetching the task again
             sleep(_POLL_INTERVAL)
             
-    def is_active(self):
-        if not self.__session:
-            return False
-        try:
-            # Try making an API request
-            self.api_request('GET', 'session')
-            return True
-        except (AuthenticationError, PermissionsError):
-            # We only catch authentication-related errors
-            return False
+    def poll(self):
+        # Just hit an API endpoint that does nothing but report session info
+        self.api_request('GET', 'session')
+        return True
             
     def list_images(self):
         # Get a list of uris of catalogs available to the user

--- a/jasmin_portal/identity.py
+++ b/jasmin_portal/identity.py
@@ -1,0 +1,111 @@
+"""
+Identity management functionality for the JASMIN cloud portal
+
+We use LDAP for authentication and storage of user information
+"""
+
+__author__ = "Matt Pryor"
+__copyright__ = "Copyright 2015 UK Science and Technology Facilities Council"
+
+
+import functools, re
+
+import ldap3
+from ldap3.utils.dn import parse_dn
+from pyramid import events
+from pyramid_ldap3 import get_ldap_connector
+
+
+def setup(config, settings):
+    """
+    Given a pyramid configurator and a settings dictionary, configure the app
+    for identity management
+    """
+    # We want to use LDAP
+    config.include('pyramid_ldap3')
+    
+    # Define our LDAP configuration
+    config.ldap_setup(
+        settings['ldap.server'], bind = settings['ldap.bind_dn'], passwd = settings['ldap.bind_pass']
+    )
+    config.ldap_set_login_query(
+        base_dn = settings['ldap.user_base'],
+        filter_tmpl = '(uid=%(login)s)',
+        scope = ldap3.SEARCH_SCOPE_SINGLE_LEVEL
+    )
+    config.ldap_set_groups_query(
+        base_dn = settings['ldap.group_base'],
+        filter_tmpl = '(&(objectClass=posixGroup)(memberUid=%(userdn)s))',
+        scope = ldap3.SEARCH_SCOPE_SINGLE_LEVEL
+    )
+    
+    # Add a couple of useful properties to request
+    
+    def current_userid(request):
+        # Just reifies the authenticated_userid, so that the check is only done once
+        return request.authenticated_userid
+    
+    config.add_request_method(current_userid, reify = True)
+    
+    def current_org(request):
+        # Gets the current organisation for the request
+        try:
+            return request.matchdict['org'].lower()
+        except (AttributeError, KeyError):
+            return None
+    
+    config.add_request_method(current_org, reify = True)
+    
+    def available_orgs(request):
+        # Returns the orgs for the current user
+        if request.current_userid:
+            return orgs_for_user(request.current_userid, request)
+        return []
+    
+    config.add_request_method(available_orgs, reify = True)
+    
+    # Inject the org from the current request into route_url and route_path if not overridden
+    # Because we need access to the original versions of the functions to defer to, we inject
+    # overwrite the functions at request creation time using events
+    def overwrite_path_funcs(event):
+        def inject_org(request, kw):
+            # If org is not present in kw, try to inject it from the request before
+            # returning kw
+            if 'org' not in kw and request.current_org:
+                kw['org'] = request.current_org
+            return kw
+        
+        # Overwrite the route_url and route_path functions with versions that inject the org
+        request = event.request
+        
+        route_url = request.route_url
+        request.route_url = lambda route, *args, **kw: route_url(route, *args, **inject_org(request, kw))
+        
+        route_path = request.route_path
+        request.route_path = lambda route, *args, **kw: route_path(route, *args, **inject_org(request, kw))
+    
+    config.add_subscriber(overwrite_path_funcs, events.NewRequest)
+    
+    return config
+
+
+def authenticate_user(request, userid, password):
+    """
+    Attempt to authenticate the user, and return True if successful, False otherwise
+    """
+    conn = get_ldap_connector(request)
+    return ( conn.authenticate(userid, password) is not None )
+
+
+@functools.lru_cache(maxsize = 32)
+def orgs_for_user(userid, request):
+    """
+    Returns the organisations that the user with the given user id belongs to
+    
+    The results are cached for the duration of the request
+    """
+    conn = get_ldap_connector(request)
+    pattern = re.compile(request.registry.settings['ldap.group_pattern'])
+    groups = ( parse_dn(dn).pop(0)[1].lower() for dn, _ in conn.user_groups(userid) )
+    matches = ( pattern.match(g) for g in groups )
+    return [ m.group('org') for m in matches if m ]

--- a/jasmin_portal/static/css/site.css
+++ b/jasmin_portal/static/css/site.css
@@ -35,7 +35,7 @@ footer {
 /* Other small fixes */
 
 .dropdown-menu {
-    width : 100%;
+    min-width : 100%;
 }
 
 .panel-grid-row, .panel-grid-row [class*="col-"] {

--- a/jasmin_portal/templates/dashboard.jinja2
+++ b/jasmin_portal/templates/dashboard.jinja2
@@ -1,0 +1,9 @@
+{% extends "templates/layout.jinja2" %}
+
+{% block pagetitle %}Dashboard{% endblock %}
+
+{% block content %}
+<div class="row">
+    <h2>Dashboard in progress</h2>
+</div>
+{% endblock %}

--- a/jasmin_portal/templates/layout.jinja2
+++ b/jasmin_portal/templates/layout.jinja2
@@ -36,7 +36,7 @@
                     </div>
                 
                     <div id="nav-main" class="collapse navbar-collapse">
-                        {%- if request.authenticated_userid %}
+                        {%- if request.current_userid and request.current_org %}
                             <ul class="nav navbar-nav navbar-left">
                                 <li {% if request.matched_route.name == 'machines' %}class="active"{% endif %}>
                                     <a href="{{ request.route_url('machines') }}">Machines</a>
@@ -45,19 +45,31 @@
                                     <a href="{{ request.route_url('catalogue') }}">Catalogue</a>
                                 </li>
                             </ul>
-
+                        {%- endif %}
+                        
+                        {%- if request.current_userid %}
                             <ul class="nav navbar-nav navbar-right">
                                 <li class="dropdown">
                                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                                         <i class="fa fa-user"></i>&nbsp;
-                                        {{ request.authenticated_userid }}
+                                        {{ request.current_userid }}{% if request.current_org %}@<strong>{{ request.current_org }}</strong>{% endif %}
                                         <span class="caret"></span>
                                     </a>
                                     <ul class="dropdown-menu">
-                                        <li><a href="{{ request.route_url('logout') }}"><i class="fa fa-sign-out"></i>&nbsp; Sign out</a></li>
+                                        {%- for org in request.available_orgs %}
+		                                    <li {% if org == request.current_org %}class="active"{% endif %}>
+		                                    	<a href="{{ request.route_url('machines', org = org) }}"><i class="fa fa-group fa-fw"></i>&nbsp; {{ org }}</a>
+		                                    </li>
+		                                {%- endfor %}
+						            	<li role="separator" class="divider"></li>
+                                        <li><a href="{{ request.route_url('logout') }}"><i class="fa fa-sign-out fa-fw"></i>&nbsp; Sign out</a></li>
                                     </ul>
                                 </li>
                             </ul>
+                        {%- else %}
+	                        <ul class="nav navbar-nav navbar-right">
+	                            <li><a href="{{ request.route_url('login') }}">Log in</a></li>
+	                        </ul>
                         {%- endif %}
                         
                         <ul class="nav navbar-nav navbar-right">

--- a/jasmin_portal/templates/login.jinja2
+++ b/jasmin_portal/templates/login.jinja2
@@ -1,6 +1,6 @@
 {% extends "templates/layout.jinja2" %}
 
-{% block pagetitle %}Login to {{ request.matchdict.org }}{% endblock %}
+{% block pagetitle %}Log in{% endblock %}
 
 {% block content %}
 <div class="col-md-6 col-md-offset-3">

--- a/jasmin_portal/templates/notfound.jinja2
+++ b/jasmin_portal/templates/notfound.jinja2
@@ -1,6 +1,0 @@
-{% extends "templates/layout.jinja2" %}
-
-{% block pagetitle %}Not Found{% endblock %}
-
-{% block content %}
-{% endblock %}

--- a/jasmin_portal/test/test_vcd_provider.py
+++ b/jasmin_portal/test/test_vcd_provider.py
@@ -13,7 +13,7 @@ import unittest, uuid
 from jasmin_portal.test.util import IntegrationTest
 from jasmin_portal.test.vcd_settings import endpoint, username, password
 
-from jasmin_portal.cloudservices import MachineStatus
+from jasmin_portal.cloudservices import MachineStatus, CloudServiceError
 from jasmin_portal.cloudservices.vcloud import VCloudProvider
 
 
@@ -43,7 +43,7 @@ class TestVcdProvider(unittest.TestCase, IntegrationTest):
         """
         p = VCloudProvider(endpoint)
         self.session = p.new_session(username, password)
-        self.assertTrue(self.session.is_active())
+        self.assertTrue(self.session.poll())
         
     def list_images(self, input):
         """
@@ -152,6 +152,6 @@ class TestVcdProvider(unittest.TestCase, IntegrationTest):
         Closes the session and checks that it is no longer active
         """
         self.session.close()
-        self.assertFalse(self.session.is_active())
+        self.assertRaises(CloudServiceError, self.session.poll)
         self.session = None
     

--- a/jasmin_portal/views.py
+++ b/jasmin_portal/views.py
@@ -82,7 +82,7 @@ def login(request):
         password = request.params['password']
         try:
             
-            provider = vcloud.VCloudProvider(request.registry.settings['vcloud_endpoint'])
+            provider = vcloud.VCloudProvider(request.registry.settings['vcloud.endpoint'])
             request.vcd_session = provider.new_session(username, password)
             # When a user logs in, force a refresh of the CSRF token
             request.session.new_csrf_token()
@@ -159,7 +159,7 @@ def catalogue(request):
     except cloud.CloudServiceError as e:
         request.session.flash(str(e), 'error')
     if items:
-        with open(request.registry.settings['catalogue_file']) as f:
+        with open(request.registry.settings['catalogue.file']) as f:
             overrides = json.load(f)
     return {
         'items' : [overrides[i['uuid']] if i['uuid'] in overrides else i for i in items]
@@ -214,7 +214,7 @@ def new_machine(request):
     try:
         image_id = request.matchdict['id']
         # Try to load the image data from the JSON file
-        with open(request.registry.settings['catalogue_file']) as f:
+        with open(request.registry.settings['catalogue.file']) as f:
             items = json.load(f)
         if image_id in items:
             image = items[image_id]

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ requires = [
     'pyramid',
     'pyramid_debugtoolbar',
     'pyramid_jinja2',
+    'jinja2',
+    'pyramid_ldap3',
+    'ldap3',
     'requests',
 ]
 


### PR DESCRIPTION
This ticket enables authentication for multiple orgs using LDAP. At login, a vCD session is created for each org and kept alive with each request, meaning that we don't have to store the password, even in memory (we only store the auth token for the session).